### PR TITLE
Fix ime switch issue in #161

### DIFF
--- a/src/eve.c
+++ b/src/eve.c
@@ -534,7 +534,7 @@ void move_in_win(ClientState *cs, int x, int y)
         module_cb1(cs)->module_move_win(x, y);
       break;
     default:
-      if (!cs->in_method)
+      if (cs->in_method < 0)
         return;
       move_win_gtab(x, y);
   }
@@ -758,7 +758,7 @@ void init_state_chinese(ClientState *cs)
 {
   cs->im_state = HIME_STATE_CHINESE;
   set_tsin_pho_mode0(cs);
-  if (!cs->in_method)
+  if (cs->in_method < 0)
 #if UNIX
     init_in_method(default_input_method);
 #else


### PR DESCRIPTION
處理 #161 的行為。

cs->in_method 是 index，所以原本用 !cs->in_method 的方式會把第一個輸入法切走換成預設輸入法。

主要影響的程式碼是在 392f5a7e 中的 761 行的修改。537行連帶一併修改。

就目前我所了解其他部分的運作，應該是不會影響到原本的行為。請 review 過，沒問題的話再 merge。
