### PR TITLE
Pass LDFLAGS envvars to Makefile

### DIFF
--- a/configure
+++ b/configure
@@ -48,7 +48,7 @@ if [ $? = 0 ]; then
   FREEBSD=1
 fi
 
-SO_FLAGS="-shared -Wl,--as-needed"
+SO_FLAGS="$LDFLAGS -shared -Wl,--as-needed"
 MAC_OS=0
 uname | grep Darwin > /dev/null 2> /dev/null
 if [ $? = 0 ]; then
@@ -495,7 +495,8 @@ echo "filterdir=\$(datadir_r)/hime/filter" >> config.mak
 echo "libdir=\$(DESTDIR)$libdir" >> config.mak
 echo "himelibdir=\$(libdir)/hime" >> config.mak
 echo "includedir=\$(DESTDIR)$includedir" >> config.mak
-echo "LDFLAGS=-Wl,--as-needed -lX11 -lm" >> config.mak
+echo "LDFLAGS_ENV=$LDFLAGS" >> config.mak
+echo "LDFLAGS=$LDFLAGS -Wl,--as-needed -lX11 -lm" >> config.mak
 if [ $FREEBSD -eq 0 ]; then
 	echo "LDFLAGS+=$GTKLDFLAGS -lX11 -ldl" >> config.mak
 else

--- a/src/qt4-im/Makefile
+++ b/src/qt4-im/Makefile
@@ -9,7 +9,7 @@ CXXFLAGS=$(OPTFLAGS) $(INCS) -Wall -D_REENTRANT -DUNIX=1 -fPIC  -DQT4 -DQT_SHARE
 -DQT_IMMODULE -DPIC
 OBJS= moc_hime-qt.o hime-qt.o im-hime-qt.o hime-imcontext-qt.o
 .SUFFIXES:	.c .cpp .a .so .E .h
-LDFLAGS=-L../im-client -lhime-im-client `pkg-config QtCore QtGui --libs`
+LDFLAGS=$(LDFLAGS_ENV) -L../im-client -lhime-im-client `pkg-config QtCore QtGui --libs`
 all:    im-hime.so
 
 .cpp.E:


### PR DESCRIPTION
Debian now introduces build flags to strengthen the robustness of the system.
http://wiki.debian.org/Hardening

But I found that I cannot pass LDFLAGS envvars to the build scripts, and this pull request tries to pass LDFLAGS envvars to Makefile.

And, please help me checking if we can pass CFLAGS, CXXFLAGS, LDFLAGS flags to its corresponding build commands. Thanks!
