### PR TITLE
Do no treat GNU/kFreeBSD as a FreeBSD distro.

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ if [ $? = 0 ]; then
 fi
 
 FREEBSD=0
-uname | grep FreeBSD > /dev/null 2> /dev/null
+uname | grep FreeBSD | grep -v GNU/kFreeBSD > /dev/null 2> /dev/null
 if [ $? = 0 ]; then
   FREEBSD=1
 fi


### PR DESCRIPTION
Related bug report: https://bugs.debian.org/739735

It seems `FREEBSD` variable affects `-ldl` flag and manpage directory, but in Debian GNU/kFreeBSD it should be in Debian fashion.
