### PR TITLE
Check return value of getenv("HOME")

### DIFF
--- a/src/hime-conf.c
+++ b/src/hime-conf.c
@@ -37,7 +37,10 @@ void init_TableDir()
 
 void get_hime_dir(char *tt)
 {
-    strcpy(tt,(char *)getenv("HOME"));
+    char *home = getenv("HOME");
+    if (!home)
+      home = "";
+    strcpy(tt,home);
     strcat(tt,"/.config/hime");
 }
 

--- a/src/hime-setup.c
+++ b/src/hime-setup.c
@@ -136,10 +136,13 @@ static void cb_ts_export()
 static void ts_import(const gchar *selected_filename)
 {
    char cmd[256];
+   char *home = getenv("HOME");
+   if (!home)
+      home = "";
    if (inmd[default_input_method].method_type==method_type_TSIN) {
      snprintf(cmd, sizeof(cmd),
         "cd %s/.config/hime && "HIME_BIN_DIR"/hime-tsd2a32 %s > tmpfile && cat %s >> tmpfile && "HIME_BIN_DIR"/hime-tsa2d32 tmpfile %s",
-        getenv("HOME"), tsin32_f, selected_filename, tsin32_f);
+        home, tsin32_f, selected_filename, tsin32_f);
      int res = system(cmd);
      res = 0;
      create_result_win(res, cmd);


### PR DESCRIPTION
Fix the following crash issues in debian.

https://bugs.debian.org/716028
https://bugs.debian.org/716029
https://bugs.debian.org/716030
https://bugs.debian.org/716034
https://bugs.debian.org/716085
