### PR TITLE
Defined _XSERVER64 in header

### DIFF
--- a/src/im-client/hime-im-client.c
+++ b/src/im-client/hime-im-client.c
@@ -25,9 +25,6 @@
 #include <unistd.h>
 #include <signal.h>
 #include <errno.h>
-#ifndef _XSERVER64
-#define _XSERVER64
-#endif
 #include "hime.h"
 #include "hime-protocol.h"
 #include "hime-im-client.h"

--- a/src/im-client/hime-im-client.h
+++ b/src/im-client/hime-im-client.h
@@ -17,6 +17,11 @@
 
 #ifndef HIME_IM_CLIENT_H
 #define HIME_IM_CLIENT_H
+
+#ifndef _XSERVER64
+#define _XSERVER64
+#endif
+
 struct HIME_PASSWD;
 
 typedef struct HIME_client_handle_S {


### PR DESCRIPTION
See [0], the _XSERVER64 affects the struct HIME_client_handle_S, so it
shall be defined alone with HIME_client_handle_S to prevent struct
conflict.

[0] https://bugs.debian.org/750375
