### PR TITLE
Use bash instead of sh in nobopomofo

### DIFF
--- a/filter/nobopomofo
+++ b/filter/nobopomofo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # hime filter nobopomofo version 0.0.4
   read -r -t 1 aa
   echo -n $aa


### PR DESCRIPTION
See http://bugs.debian.org/772236. nobopomofo uses extra feature that
does not belong to sh.
