### PR TITLE
Fix won't build in path with spaces(incomplete) (Issue #520)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ install:
 	   $(MAKE) -C $$d install || exit 1; \
 	done
 	@if [ "$(prefix)" = /usr/local ]; then \
-	   install -d $(DOC_DIR); \
-	   install -m 644 ChangeLog $(DOC_DIR); \
+	   install -d "$(DOC_DIR)"; \
+	   install -m 644 ChangeLog "$(DOC_DIR)"; \
 	else \
-	   install -d $(DOC_DIR_i); \
-	   install -m 644 ChangeLog $(DOC_DIR_i); \
+	   install -d "$(DOC_DIR_i)"; \
+	   install -m 644 ChangeLog "$(DOC_DIR_i)"; \
 	fi
 
 clean:

--- a/data/Makefile
+++ b/data/Makefile
@@ -108,9 +108,9 @@ gtab.list: $(REMOVE_TSIN)
 	touch gtab.list
 
 install:
-	install -d $(HIME_TABLE_DIR_i)
-	install -m 644 $(DATA) $(DATAKEEP) $(HIME_TABLE_DIR_i)
-#	cd $(HIME_TABLE_DIR_i); bzip2 -f *.gtab
+	install -d "$(HIME_TABLE_DIR_i)"
+	install -m 644 $(DATA) $(DATAKEEP) "$(HIME_TABLE_DIR_i)"
+#	cd "$(HIME_TABLE_DIR_i)"; bzip2 -f *.gtab
 
 clean:
 	@echo "clean up"

--- a/filter/Makefile
+++ b/filter/Makefile
@@ -3,8 +3,8 @@ include ../config.mak
 all:
 
 install:
-	install -d $(filterdir)
-	install -m 755 [a-z]* $(filterdir)
+	install -d "$(filterdir)"
+	install -m 755 [a-z]* "$(filterdir)"
 
 clean:
 	@echo "clean up"

--- a/icons/Makefile
+++ b/icons/Makefile
@@ -12,14 +12,14 @@ endif
 all:
 
 install:
-	install -d $(datadir)/pixmaps
-	install -m 644 hime.png $(datadir)/pixmaps
-	install -d $(HIME_DEFAULT_ICON_DIR_i)
-	install -m 644 30x30/*.png $(HIME_DEFAULT_ICON_DIR_i)
+	install -d "$(datadir)/pixmaps"
+	install -m 644 hime.png "$(datadir)/pixmaps"
+	install -d "$(HIME_DEFAULT_ICON_DIR_i)"
+	install -m 644 30x30/*.png "$(HIME_DEFAULT_ICON_DIR_i)"
 	@set -x ; for d in $(DIR); do \
 	   $(ECHO) -e "\x1b[1;32m** installing icons/$$d\x1b[0m"; \
-	   install -d $(HIME_DEFAULT_ICON_DIR_i)/$$d ; \
-	   install -m 644 $$d/*.png $(HIME_DEFAULT_ICON_DIR_i)/$$d ; \
+	   install -d "$(HIME_DEFAULT_ICON_DIR_i)/$$d" ; \
+	   install -m 644 $$d/*.png "$(HIME_DEFAULT_ICON_DIR_i)/$$d" ; \
 	done
 
 clean:

--- a/man/Makefile
+++ b/man/Makefile
@@ -3,8 +3,8 @@ include ../config.mak
 all:
 
 install:
-	install -d $(man1dir)
-	install -m 644 *.1 $(man1dir)
+	install -d "$(man1dir)"
+	install -m 644 *.1 "$(man1dir)"
 
 clean:
 	@echo "clean up"

--- a/menu/Makefile
+++ b/menu/Makefile
@@ -7,8 +7,8 @@ install:
 	   install hime-setup.desktop /usr/share/applications; \
 	   which update-menus > /dev/null 2>&1 && update-menus || exit 0; \
 	else \
-	   install -d $(datadir)/applications; \
-	   install -m 644 hime-setup.desktop $(datadir)/applications; \
+	   install -d "$(datadir)/applications"; \
+	   install -m 644 hime-setup.desktop "$(datadir)/applications"; \
 	fi
 
 clean:

--- a/po/Makefile
+++ b/po/Makefile
@@ -31,8 +31,8 @@ update-po: hime.pot
 install:
 	@set -x ; for d in $(LANG_FILE); do \
 	   $(ECHO) -e "\x1b[1;32m** installing $$d.mo\x1b[0m"; \
-	   install -d $(datadir)/locale/$$d/LC_MESSAGES ; \
-	   install -m 644 $$d.gmo $(datadir)/locale/$$d/LC_MESSAGES/hime.mo ; \
+	   install -d "$(datadir)/locale/$$d/LC_MESSAGES" ; \
+	   install -m 644 $$d.gmo "$(datadir)/locale/$$d/LC_MESSAGES/hime.mo"; \
 	done
 
 clean:

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -6,10 +6,10 @@ BIN_SCRIPTS=hime-env
 all:	$(SCRIPTS)
 
 install:
-	install -d $(HIME_SCRIPT_DIR_i)
-	install -m 755 $(SCRIPTS) $(HIME_SCRIPT_DIR_i)
-	install -d $(bindir)
-	install -m 755 $(BIN_SCRIPTS) $(bindir)
+	install -d "$(HIME_SCRIPT_DIR_i)"
+	install -m 755 $(SCRIPTS) "$(HIME_SCRIPT_DIR_i)"
+	install -d "$(bindir)"
+	install -m 755 $(BIN_SCRIPTS) "$(bindir)"
 
 clean:
 	@echo "clean up"

--- a/src/Makefile
+++ b/src/Makefile
@@ -272,16 +272,16 @@ hime-tsin2gtab-phrase: $(OBJS_tsin2gtab_phrase)
 	@$(CCLD) -o $@ $^ $(LDFLAGS)
 
 install:
-	install -d $(bindir)
-	install $(PROGS) $(bindir)
-	rm -f $(bindir)/hime-trad2sim; ln -sf hime-sim2trad $(bindir)/hime-trad2sim
-	rm -f $(bindir)/hime-exit; ln -sf hime-gb-toggle $(bindir)/hime-exit
-	rm -f $(bindir)/hime-trad; ln -sf hime-gb-toggle $(bindir)/hime-trad
-	rm -f $(bindir)/hime-sim; ln -sf hime-gb-toggle $(bindir)/hime-sim
-	rm -f $(bindir)/hime-kbm-toggle; ln -sf hime-gb-toggle $(bindir)/hime-kbm-toggle
-	install -d $(himelibdir)
-	install -d $(includedir)
-	install -m 644 im-client/hime-im-client.h im-client/hime-im-client-attr.h $(includedir)
+	install -d "$(bindir)"
+	install $(PROGS) "$(bindir)"
+	rm -f "$(bindir)/hime-trad2sim"; ln -sf hime-sim2trad "$(bindir)/hime-trad2sim"
+	rm -f "$(bindir)/hime-exit"; ln -sf hime-gb-toggle "$(bindir)/hime-exit"
+	rm -f "$(bindir)/hime-trad"; ln -sf hime-gb-toggle "$(bindir)/hime-trad"
+	rm -f "$(bindir)/hime-sim"; ln -sf hime-gb-toggle "$(bindir)/hime-sim"
+	rm -f "$(bindir)/hime-kbm-toggle"; ln -sf hime-gb-toggle "$(bindir)/hime-kbm-toggle"
+	install -d "$(himelibdir)"
+	install -d "$(includedir)"
+	install -m 644 im-client/hime-im-client.h im-client/hime-im-client-attr.h "$(includedir)"
 	$(MAKE) -C im-client install
 	$(MAKE) -C modules install
 	if [ $(GTK_IM) = 'Y' ]; then $(MAKE) -C gtk-im install; fi

--- a/src/im-client/Makefile
+++ b/src/im-client/Makefile
@@ -38,9 +38,9 @@ endif
 LOCALLIB=/usr/local/$(LIB)
 
 install:
-	install -d $(himelibdir)
-	install -m 755 $(SOFILEVER) $(himelibdir)
-	cd $(himelibdir); rm -f $(SOFILE); ln -s $(SOFILEVER) $(SOFILE); \
+	install -d "$(himelibdir)"
+	install -m 755 $(SOFILEVER) "$(himelibdir)"
+	cd "$(himelibdir)"; rm -f $(SOFILE); ln -s $(SOFILEVER) $(SOFILE); \
 	ln -sf $(SOFILEVER) $(SOFILE).1
 
 hime-conf.o: ../hime-conf.c

--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -34,7 +34,7 @@ chewing-module.so: $(chewing_module_obj) $(chewing_module_so)
 	@$(CCLD) $(SO_FLAGS) -o $@ $(chewing_module_obj) $(chewing_module_so) $(LDFLAGS) $(shell pkg-config --cflags --libs chewing)
 
 install:
-	install $(HIME_MODULE) $(himelibdir)
+	install $(HIME_MODULE) "$(himelibdir)"
 
 clean:
 	@echo "clean up"

--- a/src/qt4-im/Makefile
+++ b/src/qt4-im/Makefile
@@ -31,8 +31,8 @@ im-hime.so: $(OBJS)
 	@rm -f core.*
 
 install:
-	install -d $(QT4_IM_DIR); \
-	install -m 755 im-hime.so $(QT4_IM_DIR)
+	install -d "$(QT4_IM_DIR)"; \
+	install -m 755 im-hime.so "$(QT4_IM_DIR)"
 
 clean:
 	@echo "clean up"

--- a/src/qt5-im/Makefile
+++ b/src/qt5-im/Makefile
@@ -40,8 +40,8 @@ im-hime.so: $(OBJS)
 	@rm -f core.*
 
 install:
-	install -d $(QT5_IM_DIR); \
-	install -m 755 im-hime.so $(QT5_IM_DIR)
+	install -d "$(QT5_IM_DIR)"; \
+	install -m 755 im-hime.so "$(QT5_IM_DIR)"
 
 clean:
 	@echo "clean up"


### PR DESCRIPTION
Currently build will fail if your path contains space, this patch deals
with the issue by quoting destination paths in under the "install" make
targets.

Note that this patch doesn't deal with all Makefiles and need further
patch & review.

Upstream-Issue: #520 
Signed-off-by: Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>