### PR TITLE
Patch issue 539

### DIFF
--- a/src/gtk-im/Makefile
+++ b/src/gtk-im/Makefile
@@ -41,16 +41,16 @@ clean:
 
 install:
 	if [ "$(prefix)" = "/usr/local" -o "$(prefix)" = "/usr" ]; then \
-		install -d $(MODULEDIR); \
-		install -m 755 im-hime.so $(MODULEDIR); \
+		install -d "$(MODULEDIR)"; \
+		install -m 755 im-hime.so "$(MODULEDIR)"; \
 		if [ "$(prefix)" = "/usr/local" ]; then \
-			if [ -d $(DESTDIR)/etc/gtk-2.0 ]; then \
-				cd $(DESTDIR)/etc/gtk-2.0; $(IMMODULES_QUERY) > gtk.immodules; \
+			if [ -d "$(DESTDIR)/etc/gtk-2.0" ]; then \
+				cd "$(DESTDIR)/etc/gtk-2.0"; $(IMMODULES_QUERY) > gtk.immodules; \
 			fi \
 		fi \
 	else \
-		install -d $(IMMODULES); \
-		install -m 755 im-hime.so $(IMMODULES); \
+		install -d "$(IMMODULES)"; \
+		install -m 755 im-hime.so "$(IMMODULES)"; \
 	fi
 
 .depend:

--- a/src/gtk3-im/Makefile
+++ b/src/gtk3-im/Makefile
@@ -41,16 +41,16 @@ clean:
 
 install:
 	if [ "$(prefix)" = "/usr/local" -o "$(prefix)" = "/usr" ]; then \
-		install -d $(MODULEDIR); \
-		install -m 755 im-hime.so $(MODULEDIR); \
+		install -d "$(MODULEDIR)"; \
+		install -m 755 im-hime.so "$(MODULEDIR)"; \
 		if [ "$(prefix)" = "/usr/local" ]; then \
 			if [ -f "$(IMMODULES_QUERY)" -a -x "$(IMMODULES_QUERY)" ]; then \
 				GTK_IM_MODULE_FILE=$(IMMODULES_CACHE) $(IMMODULES_QUERY) --update-cache; \
 			fi \
 		fi \
 	else \
-		install -d $(IMMODULES); \
-		install -m 755 im-hime.so $(IMMODULES); \
+		install -d "$(IMMODULES)"; \
+		install -m 755 im-hime.so "$(IMMODULES)"; \
 	fi
 
 .depend:


### PR DESCRIPTION
Currently build will fail if your path contains space, this patch deals
with the issue by quoting destination paths in under the "install" make
targets.

Note that this patch doesn't deal with all Makefiles and need further
patch & review.

Signed-off-by: Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>