### PR TITLE
WM: the chewing setting window should not be covered

### DIFF
--- a/src/modules/hime-setup-chewing.c
+++ b/src/modules/hime-setup-chewing.c
@@ -98,6 +98,8 @@ void module_setup_window_create (GtkButton *button, gpointer data_hime_setup_win
     hime_chewing_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     if (data_hime_setup_window_type_utility)
       gtk_window_set_type_hint(GTK_WINDOW(hime_chewing_window), GDK_WINDOW_TYPE_HINT_UTILITY);
+    else
+      gtk_window_set_type_hint(GTK_WINDOW(hime_chewing_window), GDK_WINDOW_TYPE_HINT_DIALOG);
     /* main setup win setting */
     gtk_window_set_position (GTK_WINDOW (hime_chewing_window),
                              GTK_WIN_POS_MOUSE);


### PR DESCRIPTION
The commit is for displaying the chewing setting window correctly
with different value of "hime_setup_window_type_utility".

The setting variable "hime_setup_window_type_utility" was first
create from commit d80463.
The corresponding functions of setting the variable value were
commented out temporarily in commit 917b1e.