### PR TITLE
Revert "tsin: send out the buffer when changing the mode from Ch to En"

### DIFF
--- a/src/tsin.c
+++ b/src/tsin.c
@@ -1553,7 +1553,6 @@ int feedkey_pp(KeySym xkey, int kbstate)
 //	  dbg("feedkey_pp\n");
      key_press_alt = TRUE;
      key_press_ctrl = FALSE;
-     flush_tsin_buffer();
    } else
    if ((xkey==XK_Control_L||xkey==XK_Control_R) && !key_press_ctrl && tss.pre_selN) {
 //	  dbg("feedkey_pp\n");


### PR DESCRIPTION
This reverts commit 38131bbfffede0ba96751fdd9b8c379bdc7c52d8.

This caused unexpected flushing when selecting from preselection word list.