### PR TITLE
Refactor and polish about.c

### DIFF
--- a/configure
+++ b/configure
@@ -531,11 +531,15 @@ includedir=$prefix/include
 optdir=/opt
 
 if [ -z "$CFLAGS" ]; then
-  OPTFLAGS="-Wall"
+    OPTFLAGS="-Wall"
+    CFLAGS="-std=gnu17"
+    CXXFLAGS="-std=gnu++17"
 else
   OPTFLAGS="$CFLAGS"
 fi
-echo "-> CFLAGS = $CFLAGS."
+echo "-> CFLAGS = $CFLAGS"
+echo "-> CXXFLAGS = $CXXFLAGS"
+echo "-> OPTFLAGS = $OPTFLAGS"
 
 if [ -z "$CC" ]; then
   CC=gcc

--- a/src/about.c
+++ b/src/about.c
@@ -1,4 +1,6 @@
-/* Copyright (C) 2011 Edward Der-Hua Liu, Hsin-Chu, Taiwan
+/*
+ * Copyright (C) 2020 The HIME team, Taiwan
+ * Copyright (C) 2011 Edward Der-Hua Liu, Hsin-Chu, Taiwan
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,78 +22,76 @@
 static GtkWidget *about_window;
 
 /* Our usual callback function */
-static void callback_close( GtkWidget *widget, gpointer   data )
+static void callback_close(GtkWidget *widget, gpointer dummy)
 {
-   gtk_widget_destroy(about_window);
-   about_window = NULL;
+    gtk_widget_destroy(about_window);
+    about_window = NULL;
 }
 
 void create_about_window()
 {
+    const gboolean no_expand = FALSE;
+    const gboolean no_fill = FALSE;
+    const guint padding = 3;
+
     if (about_window) {
-      gtk_window_present(GTK_WINDOW(about_window));
-      return;
+        gtk_window_present(GTK_WINDOW (about_window));
+        return;
     }
 
-    GtkWidget *vbox = gtk_vbox_new(FALSE,3);
-    gtk_orientable_set_orientation(GTK_ORIENTABLE(vbox), GTK_ORIENTATION_VERTICAL);
-    GtkWidget *hbox;
-
     /* Create a new about_window */
-    about_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_position(GTK_WINDOW(about_window), GTK_WIN_POS_CENTER);
+    about_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
-    gtk_window_set_has_resize_grip(GTK_WINDOW(about_window), FALSE);
-
-    gtk_window_set_title (GTK_WINDOW (about_window), _("About hime"));
+    /* Sets attributes of the about_window. */
+    gtk_window_set_title(GTK_WINDOW (about_window), _("About hime"));
+    gtk_container_set_border_width(GTK_CONTAINER (about_window), 10);
+    gtk_window_set_position(GTK_WINDOW (about_window), GTK_WIN_POS_CENTER);
 
     /* It's a good idea to do this for all windows. */
-    g_signal_connect (G_OBJECT (about_window), "destroy",
-	              G_CALLBACK (callback_close), NULL);
+    g_signal_connect(G_OBJECT (about_window), "destroy",
+                     G_CALLBACK (callback_close), NULL);
 
-    g_signal_connect (G_OBJECT (about_window), "delete_event",
-	 	      G_CALLBACK (callback_close), NULL);
-
-    /* Sets the border width of the about_window. */
-    gtk_container_set_border_width (GTK_CONTAINER (about_window), 10);
+    g_signal_connect(G_OBJECT (about_window), "delete_event",
+                     G_CALLBACK (callback_close), NULL);
 
 
+    /* Create box for icon image and label */
+    GtkWidget *hbox = gtk_hbox_new(FALSE, 0);
+    gtk_container_set_border_width(GTK_CONTAINER (hbox), 2);
+
+    GtkWidget *vbox = gtk_vbox_new(FALSE, 3);
+    gtk_orientable_set_orientation(
+        GTK_ORIENTABLE (vbox), GTK_ORIENTATION_VERTICAL);
+    gtk_box_pack_start(GTK_BOX (vbox), hbox, no_expand, no_fill, padding);
+
+    GtkWidget *separator = gtk_hseparator_new();
+    gtk_box_pack_start(GTK_BOX (vbox), separator, no_expand, no_fill, padding);
+
+
+    /* hime icon image and label */
+    GtkWidget *image = gtk_image_new_from_file(SYS_ICON_DIR "/hime.png");
     GtkWidget *label_version;
-    GtkWidget *image;
-
-    /* Create box for image and label */
-    hbox = gtk_hbox_new (FALSE, 0);
-    gtk_container_set_border_width (GTK_CONTAINER (hbox), 2);
-
-    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 3);
-
-    GtkWidget *separator = gtk_hseparator_new ();
-    gtk_box_pack_start(GTK_BOX(vbox), separator, FALSE, FALSE, 3);
-
-    image = gtk_image_new_from_file (SYS_ICON_DIR"/hime.png");
-
 #if GIT_HAVE
-    label_version = gtk_label_new ("version " HIME_VERSION "\n(git " GIT_HASH ")");
+    label_version = gtk_label_new("version " HIME_VERSION "\n(git " GIT_HASH ")");
 #else
-    label_version = gtk_label_new ("version " HIME_VERSION);
+    label_version = gtk_label_new("version " HIME_VERSION);
 #endif
 
-    gtk_box_pack_start (GTK_BOX (hbox), image, FALSE, FALSE, 3);
-    gtk_box_pack_start (GTK_BOX (hbox), label_version, FALSE, FALSE, 3);
+    gtk_box_pack_start(GTK_BOX (hbox), image, no_expand, no_fill, padding);
+    gtk_box_pack_start(GTK_BOX (hbox), label_version, no_expand, no_fill, padding);
+    gtk_container_add(GTK_CONTAINER (about_window), vbox);
 
+    /* close button */
+    GtkWidget *button = gtk_button_new_with_label(_("Close"));
+    gtk_box_pack_start(GTK_BOX (vbox), button, no_expand, no_fill, padding);
+    g_signal_connect(G_OBJECT (button), "clicked",
+                     G_CALLBACK (callback_close), NULL);
 
-    gtk_container_add (GTK_CONTAINER (about_window), vbox);
-
-    GtkWidget *button = gtk_button_new_with_label (_("Close"));
-    gtk_box_pack_start (GTK_BOX (vbox), button, FALSE, FALSE, 3);
-    g_signal_connect (G_OBJECT (button), "clicked",
-		      G_CALLBACK (callback_close), (gpointer) "cool button");
-
-    gtk_widget_show_all (about_window);
+    gtk_widget_show_all(about_window);
     /* Put gtk_label_set_selectable() here so it will not be selected
      * by default. It is still selectable and can be copied.
      */
-    gtk_label_set_selectable (GTK_LABEL(label_version), TRUE);
+    gtk_label_set_selectable(GTK_LABEL (label_version), TRUE);
 
     return;
 }

--- a/src/hime-setup.c
+++ b/src/hime-setup.c
@@ -1,4 +1,6 @@
-/* Copyright (C) 2011 Edward Der-Hua Liu, Hsin-Chu, Taiwan
+/*
+ * Copyright (C) 2020 The HIME team, Taiwan
+ * Copyright (C) 2011 Edward Der-Hua Liu, Hsin-Chu, Taiwan
  * Copyright (C) 2012 tytsim <https://github.com/tytsim>
  * Copyright (C) 2012 Favonia <favonia@gmail.com>
  *
@@ -202,9 +204,6 @@ static void cb_ts_import_sys()
 }
 
 /* XXX */
-void create_about_window();
-
-/* XXX */
 #include "pho.h"
 #include "tsin.h"
 #include "gst.h"
@@ -324,13 +323,6 @@ static GtkWidget *create_misc_widget(void)
     pack_start_new_button_with_callback(GTK_BOX(top_widget),
         tt, G_CALLBACK (f->module_setup_window_create), GINT_TO_POINTER(hime_setup_window_type_utility));
   }
-
-#if 0
-  GtkWidget *button_about = gtk_button_new_from_stock (GTK_STOCK_ABOUT);
-  gtk_box_pack_start (GTK_BOX (top_widget), button_about, TRUE, TRUE, 5);
-  g_signal_connect (G_OBJECT (button_about), "clicked",
-                    G_CALLBACK (create_about_window),  NULL);
-#endif
 
   return top_widget;
 }

--- a/src/os-dep.h
+++ b/src/os-dep.h
@@ -9,9 +9,6 @@ void unix_exec(char *fmt,...);
 #include <X11/keysym.h>
 
 #include <glib.h>
-#if GLIB_CHECK_VERSION(2,29,8)
-#define G_CONST_RETURN const
-#endif
 
 #include <gdk/gdkx.h>
 

--- a/src/tray-double.c
+++ b/src/tray-double.c
@@ -1,4 +1,6 @@
-/* Copyright (C) 2011 Edward Der-Hua Liu, Hsin-Chu, Taiwan
+/*
+ * Copyright (C) 2020 The HIME team, Taiwan
+ * Copyright (C) 2011 Edward Der-Hua Liu, Hsin-Chu, Taiwan
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -91,6 +93,7 @@ void kbm_toggle_(GtkCheckMenuItem *checkmenuitem, gpointer dat)
   kbm_open_close(NULL, gtk_check_menu_item_get_active(checkmenuitem));
 }
 
+/* src/about.c */
 void create_about_window();
 
 static void cb_about_window(GtkCheckMenuItem *checkmenuitem, gpointer dat)


### PR DESCRIPTION
- better organize gtk code
- avoid magic constants
- enforce `GTK_MACRO ()` coding style

- use -std=gnu17 / -std=gnu++17
- deadcode cleanup in hime-setup.c and os-dep.h