### PR TITLE
Add missing const qualifier for pszZuinStr (pull request #613)

### DIFF
--- a/src/modules/chewing.c
+++ b/src/modules/chewing.c
@@ -527,7 +527,7 @@ int module_reset (void) {
 // FIXME: refine and chk
 int module_get_preedit (char *pszStr, HIME_PREEDIT_ATTR himePreeditAttr[], int *pnCursor, int *pCompFlag) {
     char *pszTmpStr = NULL;
-    char *pszZuinStr = NULL;
+    const char *pszZuinStr = NULL;
     int nIdx;
     int nLength;
     int nTotalLen = 0;


### PR DESCRIPTION
chewing_bopomofo_String_static returns a `const char *`