### PR TITLE
Update archlinux image name

### DIFF
--- a/distro/archlinux/ci/Dockerfile
+++ b/distro/archlinux/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/base:latest
+FROM archlinux:latest
 
 COPY entrypoint.sh /app/entrypoint.sh
 


### PR DESCRIPTION
- archlinux/base no longer exists

See:https://hub.docker.com/_/archlinux?tab=tags