### PR TITLE
List all tarballs in `distro/archlinux/makepkg.sh`

### DIFF
--- a/distro/archlinux/makepkg.sh
+++ b/distro/archlinux/makepkg.sh
@@ -13,7 +13,7 @@ rm -rf hime/ pkg/ src/
 
 makepkg -sf
 
-ls -ltr ./*.pkg.tar.xz
+ls -ltr ./*.pkg.tar.*
 
 set +x
 popd || exit 1


### PR DESCRIPTION
- `makepkg` may be producing .zst instead of .xz, we can list them all