### PR TITLE
Small changes to qt5 plugin to allow it build with Qt 6

### DIFF
--- a/src/qt5-im/hime-imcontext-qt.cpp
+++ b/src/qt5-im/hime-imcontext-qt.cpp
@@ -11,9 +11,9 @@
 #include <QtGui/QWindow>
 
 // confliction of qt & x11
-typedef unsigned int KeySym;
-struct Display;
-typedef unsigned int Window;
+typedef unsigned long KeySym;
+typedef struct _XDisplay Display;
+typedef unsigned long Window;
 typedef struct {
     short x, y;
 } XPoint;
@@ -244,7 +244,7 @@ void QHimePlatformInputContext::update_preedit () {
     free (str);
 }
 
-void QHimePlatformInputContext::send_event (QInputMethodEvent e) {
+void QHimePlatformInputContext::send_event (QInputMethodEvent &e) {
     QObject *input = qApp->focusObject ();
     if (!input)
         return;

--- a/src/qt5-im/hime-imcontext-qt.h
+++ b/src/qt5-im/hime-imcontext-qt.h
@@ -39,7 +39,7 @@ class QHimePlatformInputContext : public QPlatformInputContext {
 
   private:
     HIME_client_handle_S *hime_ch;
-    void send_event (QInputMethodEvent e);
+    void send_event (QInputMethodEvent &e);
     void update_preedit ();
     void cursorMoved ();
     bool send_key_press (quint32 keysym, quint32 state);


### PR DESCRIPTION
There are errors due to two reasons:
1. Qt 6 has a typedef for X types in its headers as well now, but... hime's typedefs are wrong, so they conflict. Actually, Display is a typedef to struct _XDisplay and KeySym/Window are typedefs to XID that is a typedef to unsigned long, not unsigned int.
2. QInputMethodEvent can't be copied anymore, having send_event accept a reference fixes the build.

With these changes, the plugin builds just fine with Qt 6 for me