### PR TITLE
CI: Fix CentOS 8 container error

### DIFF
--- a/distro/centos/ci/centos8/entrypoint_centos8.sh
+++ b/distro/centos/ci/centos8/entrypoint_centos8.sh
@@ -8,6 +8,9 @@ separator() {
 }
 
 # base
+cd /etc/yum.repos.d/
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 yum update -y
 yum groupinstall -y 'Development Tools'
 


### PR DESCRIPTION
CentOS Linux 8 had reached the end of life on December 31st, 2021.
The contents were removed from their mirrors and moved to
vault.centos.org.
Reference:
https://www.centos.org/centos-linux-eol/

To do the update of CentOS, the mirrors should be changed to
vault.centos.org.
Reference:
https://techglimpse.com/failed-metadata-repo-appstream-centos-8/